### PR TITLE
handle cases where newly cached items can expire before they can be r…

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -196,7 +196,7 @@ class ALClient {
    */
   async fetch(params: APIRequestParams) {
     const uri = await this.createURI(params);
-    const testCache = this.cache.get(uri.path);
+    let testCache = this.cache.get(uri.path);
     const xhr = this.axiosInstance();
     xhr.defaults.baseURL = uri.host;
     if (params.accept_header) {
@@ -205,9 +205,11 @@ class ALClient {
     if (params.response_type) {
       xhr.defaults.responseType = params.response_type;
     }
+    let originalDataResponse = null;
     if (!testCache) {
       await xhr.get(uri.path)
         .then((response) => {
+          originalDataResponse = response.data;
           this.cache.put(uri.path, response.data, params.ttl);
         })
         .catch((error) => {
@@ -218,7 +220,8 @@ class ALClient {
           return error.response.data.error;
         });
     }
-    return this.cache.get(uri.path);
+    testCache = this.cache.get(uri.path);
+    return testCache ? testCache : originalDataResponse;
   }
 
   /**


### PR DESCRIPTION
Handle cases where newly cached items can expire before they can be retrieved during fetch operations.

Original Problem: 

- Caller passes in a ttl value of zero, as they don't want any caching
- XHR call is made, response is added to cache but with ttl: 0 passed in to underlying cache lib
- At end of `fetch` we try to return the cached item
- Internally cache.get() will lookup the cached item see its expired, removes from cache and returns `null` which gets bubbled back up to the caller

Solution:

- Keep track of original XHR response, and return this if the cached item has expired
