### PR TITLE
add global axios error handler

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -141,14 +141,11 @@ class ALClient {
       },
     });
     axiosInstance.interceptors.response.use(
-      (response) => {
-      // Do something with response data
-        return response;
-      },
+      response => response,
       (error) => {
       // Do something with response error
         console.log(error);
-        return Promise.reject(error.response as AxiosResponse);
+        return Promise.reject(error.response);
       });
     return axiosInstance;
   }

--- a/test/api-client.spec.ts
+++ b/test/api-client.spec.ts
@@ -225,6 +225,6 @@ describe('When authenticating a user with a session token and mfa code', () => {
       expect(req.body()).to.equal(`{ "mfa_code": "${mfaCode}" }`);
       return res.status(200).body(defaultAuthResponse);
     });
-    await ALClient.authenticateWithToken(params, sessionToken, mfaCode);
+    await ALClient.authenticateWithMFASessionToken(params, sessionToken, mfaCode);
   });
 });


### PR DESCRIPTION
Fixed an issue where the existing handling of axios errors was not being correctly surfaced to the called in a promise friendly manner.

Also changed return values of authenticate methods to return the auth data after successful login, to follow API docs - also code in o3-auth expects this response data too.