### PR TITLE
Enhancement

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -25,6 +25,7 @@
             }
         ],
         "object-literal-key-quotes": false,
-        "member-ordering": [ true, { "order": "fields-first" } ]
+        "member-ordering": [ true, { "order": "fields-first" } ],
+        "align": [ true, "statements", "members", "elements" ]
     }
 }


### PR DESCRIPTION
- Updated `getEndpoints` method to use retry-capable axiosRequest internal method.  Because IE11 typically fails on the first handful of CORS XHR requests, these were on the first line of defense.
- Moved all logic (including retry count evaluation) to `isRetryableRequest`
- Disabled the argument and parameter evaluation for the `align` tslint rule, because requirements for vertical alignment for parameters are...  bizarre.