### PR TITLE
Fix Cache Entry Keys

### DIFF
--- a/src/al-api-client.ts
+++ b/src/al-api-client.ts
@@ -81,19 +81,24 @@ export class AlApiClient
    */
   public async get(config: APIRequestParams) {
     let normalized = await this.normalizeRequest( config );
+    const queryParams = qs.stringify(config.params);
+    let fullUrl = normalized.url;
+    if (queryParams.length > 0) {
+      fullUrl = `${fullUrl}?${queryParams}`;
+    }
     const cacheTTL = typeof( normalized.ttl ) === 'number' && normalized.ttl > 0 ? normalized.ttl : 0;
     if ( cacheTTL ) {
-      let cachedValue = this.getCachedValue( normalized.url );
+      let cachedValue = this.getCachedValue( fullUrl );
       if ( cachedValue ) {
-        this.log(`APIClient::XHR GET ${normalized.url} (FROM CACHE)` );
+        this.log(`APIClient::XHR GET ${fullUrl} (FROM CACHE)` );
         return cachedValue;
       }
     }
-    this.log(`APIClient::XHR GET ${normalized.url}` );
+    this.log(`APIClient::XHR GET ${fullUrl}` );
     const response = await this.axiosRequest( normalized );
     if ( cacheTTL ) {
-      this.log(`APIClient::cache(${normalized.url} for ${cacheTTL}ms`);
-      this.setCachedValue( normalized.url, response.data, cacheTTL );
+      this.log(`APIClient::cache(${fullUrl} for ${cacheTTL}ms`);
+      this.setCachedValue( fullUrl, response.data, cacheTTL );
     }
     return response.data;
   }

--- a/test/al-api-client.spec.ts
+++ b/test/al-api-client.spec.ts
@@ -205,6 +205,21 @@ describe('When performing two fetch operations', () => {
       expect(response).to.equal('first response');
     });
   });
+  describe('with query params supplied', () => {
+    it('should return the first server response', async () => {
+      xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar', once({
+        status: 200,
+        body: 'first response',
+      }));
+      await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', params: {foo: 'bar'} });
+      xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar', once({
+        status: 200,
+        body: 'second response',
+      }));
+      let response = await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: 'bar'}});
+      expect(response).to.equal('first response');
+    });
+  });
 });
 
 describe('When authenticating a user with credentials', () => {


### PR DESCRIPTION
This checks for presence of query params in config supplied to get/fetch calls and ensures the query string equivalents for these are appended and used for cache key entries.

This was causing pain for dashboards where we were hitting tge same endpoint but with different query strings for various charts.

WHO CAN I BLAME FOR THIS???