### PR TITLE
@al/client Enhancements

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,8 @@ module.exports = function (config) {
       },
       compilerOptions: {
         lib: [
-          "es2015",
+          "es6",
+          "es2017",
           "dom"
         ],
         esModuleInterop: true

--- a/package.json
+++ b/package.json
@@ -61,9 +61,7 @@
   "dependencies": {
     "@al/common": "^1.1.0",
     "axios": "^0.18.0",
-    "base64-js": "^1.3.0",
-    "cache": "^2.1.0",
-    "qs": "^6.7.0"
+    "base64-js": "^1.3.0"
   },
   "files": [
     "dist"

--- a/src/al-api-client.ts
+++ b/src/al-api-client.ts
@@ -2,21 +2,17 @@
  * Module to deal with discovering available endpoints
  */
 import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig, AxiosError } from 'axios';
-import cache from 'cache';
-import * as qs from 'qs';
 import * as base64JS from 'base64-js';
 import { AIMSSessionDescriptor, AIMSAccount } from './types/aims-stub.types';
 import {
     AlLocatorService, AlLocation, AlLocationDescriptor, AlLocationContext,
-    AlStopwatch, AlTriggerStream
+    AlStopwatch, AlTriggerStream, AlCabinet, AlGlobalizer,
+    AlAPIServerError, AlResponseValidationError
 } from '@al/common';
 import { AlRequestDescriptor } from './utility';
 import { AlClientBeforeRequestEvent } from './events';
 
-interface AlApiTarget {
-  host: string;
-  path: string;
-}
+export type AlEndpointsServiceCollection = {[serviceName:string]:string};
 
 /**
  * Describes a single request to be issued against an API.
@@ -28,16 +24,18 @@ export interface APIRequestParams extends AxiosRequestConfig {
    * The following parameters are used to resolve the correct service location and request path.
    * The presence of `service_name` on a request triggers this process.
    */
+  service_stack?:string;            //  Indicates which service stack the request should be issued to.  This should be one of the location identifiers in @al/common's AlLocation.
   service_name?: string;            //  Which service are we trying to talk to?
-  residency?: string;               //  What residency domain do we prefer?  Defaults to 'default'
+  residency?: string;               //  What residency domain do we prefer?  Defaults to 'default'.
   version?: string|number;          //  What version of the service do we want to talk to?
   account_id?: string;              //  Which account_id's data are we trying to access/modify through the service?
   path?: string;                    //  What is the path of the specific command within the resolved service that we are trying to interact with?
+  noEndpointsResolution?:boolean;   //  If set and truthy, endpoints resolution will *not* be used before the request is issued.
 
   /**
    * Should data fetched from this endpoint be cached?  0 ignores caching, non-zero values are treated as milliseconds to persist retrieved data in local memory.
    */
-  ttl?: number;
+  ttl?: number|boolean;
 
   /**
    * If automatic retry functionality is desired, specify the maximum number of retries and interval multiplier here.
@@ -58,36 +56,68 @@ export interface APIRequestParams extends AxiosRequestConfig {
 
 export class AlApiClient
 {
+  /**
+   * The following list of services are the ones whose endpoints will be resolved by default.  Added globally/commonly used services here for optimized API performance.
+   */
+  protected static defaultServiceList = [ "aims", "subscriptions", "search", "sources", "assets_query", "assets_write", "dashboards", "iris", "suggestions", "cargo" ];
+  protected static defaultServiceParams = {
+    service_stack:      AlLocation.InsightAPI,  //  May also be AlLocation.GlobalAPI, AlLocation.EndpointsAPI, or ALLocation.LegacyUI
+    residency:          'default',              //  "us" or "emea" or "default"
+    version:            'v1',                   //  Version of the service
+    ttl:                false                   //  Default to no caching
+  };
+
   public events:AlTriggerStream = new AlTriggerStream();
   public verbose:boolean = false;
   public defaultAccountId:string = null;        //  If specified, uses *this* account ID to resolve endpoints if no other account ID is explicitly specified
 
-  /**
-   * Service specific fallback params
-   * ttl is 1 minute by default, consumers can set cache duration in requests
-   */
-  private defaultServiceParams: APIRequestParams = {
-    residency:          'default',              //  "us" or "emea" or "default"
-    version:            'v1',                   //  Version of the service
-    ttl:                60000
-  };
-
-  private cache = new cache(60000);
+  private storage = AlCabinet.ephemeral( 'apiclient.cache' );
+  private endpointResolution:{[accountId:string]:Promise<AlEndpointsServiceCollection>} = {};
   private instance:AxiosInstance = null;
 
+  /* Default request parameters */
+  private globalServiceParams: APIRequestParams = Object.assign( {}, AlApiClient.defaultServiceParams );
+
   constructor() {}
+
+  /**
+   * Resets internal state back to its factory defaults.
+   */
+  public reset():AlApiClient {
+    this.endpointResolution = {};
+    this.instance = null;
+    this.storage.destroy();
+    this.globalServiceParams = Object.assign( {}, AlApiClient.defaultServiceParams );
+    return this;
+  }
+
+  /**
+   * This allows the host to set global parameters that will be used for every request, either for Axios or the @al/client service layer.
+   * Most notably, setting `noEndpointsResolution` to true will suppress endpoints resolution for all requests, and cause default endpoint values to be used.
+   */
+  public setGlobalParameters( parameters:APIRequestParams ):AlApiClient {
+    this.globalServiceParams = Object.assign( this.globalServiceParams, parameters );
+    return this;
+  }
 
   /**
    * GET - Return Cache, or Call for updated data
    */
   public async get(config: APIRequestParams) {
+    config.method = 'GET';
     let normalized = await this.normalizeRequest( config );
-    const queryParams = qs.stringify(config.params);
-    let fullUrl = normalized.url;
-    if (queryParams.length > 0) {
-      fullUrl = `${fullUrl}?${queryParams}`;
+    let queryParams = '';
+    if ( config.params ) {
+      queryParams = Object.entries( config.params ).map( ( [ p, v ] ) => `${p}=${encodeURIComponent( typeof( v ) === 'string' ? v : v.toString() )}` ).join("&");     //  qs.stringify in 1 line
     }
-    const cacheTTL = typeof( normalized.ttl ) === 'number' && normalized.ttl > 0 ? normalized.ttl : 0;
+    let fullUrl = `normalized.url${queryParams.length>0?'?'+queryParams:''}`;
+
+    let cacheTTL = 0;
+    if ( typeof( normalized.ttl ) === 'number' && normalized.ttl > 0 ) {
+      cacheTTL = normalized.ttl;
+    } else if ( typeof( normalized.ttl ) === 'boolean' && normalized.ttl ) {
+      cacheTTL = 60000;
+    }
     if ( cacheTTL ) {
       let cachedValue = this.getCachedValue( fullUrl );
       if ( cachedValue ) {
@@ -105,6 +135,7 @@ export class AlApiClient
   }
 
   /**
+   * @deprecated
    * Alias for GET utility method
    */
   public async fetch(config: APIRequestParams) {
@@ -151,6 +182,7 @@ export class AlApiClient
   }
 
   /**
+   * @deprecated
    * Alias for PUT utility method
    */
   public async set( config:APIRequestParams ) {
@@ -236,6 +268,7 @@ export class AlApiClient
       payload = { mfa_code: mfa };
     }
     return this.post( {
+      service_stack: AlLocation.GlobalAPI,
       service_name: 'aims',
       path: 'authenticate',
       headers: {
@@ -259,6 +292,7 @@ export class AlApiClient
       console.warn("Warning: this low level authentication method is intended only for use by other services, and will not create a reusable session.  Are you sure you intended to use it?" );
     }
     return this.post( {
+      service_stack: AlLocation.GlobalAPI,
       service_name: 'aims',
       path: 'authenticate',
       headers: {
@@ -286,55 +320,39 @@ export class AlApiClient
     return result;
   }
 
-  /**
-   * Create a default Discovery Response for Global Stack
-   */
-  public getDefaultEndpoint() {
-    let globalServiceURL = AlLocatorService.resolveURL( AlLocation.GlobalAPI );
-    if ( ! globalServiceURL ) {
-      return { global: 'https://api.global.alertlogic.com' };
+  public async normalizeRequest(config: APIRequestParams):Promise<APIRequestParams> {
+    if ( config.hasOwnProperty("service_name" ) ) {
+      // If we are using endpoints resolution to determine our calculated URL, merge globalServiceParams into our configuration
+      config = Object.assign( {}, this.globalServiceParams, config );       //  clever
+      config.url = await this.calculateRequestURL( config );
     }
-    return { global: globalServiceURL.substring( 8 ) };     //    trim protocol, which will *always* be `https://`
+    if (config.accept_header) {
+      console.warn("Deprecation warning: please do not use accept_header shortcut mechanism." );
+      if ( ! config.headers ) {
+        config.headers = {};
+      }
+      config.headers.Accept = config.accept_header;
+      delete config.accept_header;
+    }
+    if (config.response_type) {
+      config.responseType = config.response_type;
+      delete config.response_type;
+    }
+    return config;
   }
 
-  /**
-   * Get endpoint
-   * GET
-   * /endpoints/v1/:account_id/residency/:residency/services/:service_name/endpoint/:endpoint_type
-   * https://api.global-services.global.alertlogic.com/endpoints/v1/:accountId/residency/:residency/services/:serviceName/endpoint/ui
-   *
-   * Node that 'endpoint_type' here is only useful with value 'api', and this value has been hardcoded into paths for the time being.
-   */
-  public async getEndpoint(params: APIRequestParams): Promise<AxiosResponse<any>> {
-    const defaultEndpoint = this.getDefaultEndpoint();
-    let resolveAccountId = '0';
-    if ( params.hasOwnProperty( 'account_id' ) ) {
-      resolveAccountId = params.account_id;
-    } else if ( this.defaultAccountId ) {
-      resolveAccountId = this.defaultAccountId;
-    }
-    let accountId = params.hasOwnProperty( 'account_id' ) ? params.account_id : '0';
-    const uri = `https://${defaultEndpoint.global}/endpoints/v1/${resolveAccountId}/residency/default/services/${params.service_name}/endpoint/api`;
-
-    const cachedValue = this.cache.get(uri);
-    if ( cachedValue ) {
-      return cachedValue;
-    }
-
-    this.log(`APIClient:Endpoints: retrieving ${params.service_name}/api from origin`);
-    return await this.axiosRequest( { url: uri, retry_count: 3, retry_interval: 1000 } )
-                                        .then(  response => {
-                                                  this.log(`APIClient:Endpoints: ${params.service_name}/api is `, response.data );
-                                                  this.cache.put( uri, response, 15 * 60000 );          //  cache endpoints responses, which change infrequently, for 15 minutes
-                                                  return response;
-                                                } );
-  }
-
-  public async calculateEndpointURI( params: APIRequestParams ):Promise<AlApiTarget> {
-    const defaultEndpoint = this.getDefaultEndpoint();
+  protected async calculateRequestURL( params: APIRequestParams ):Promise<string> {
     let fullPath = '';
     if ( ! params.service_name ) {
-      throw new Error("Usage error: calculateEndpointURI requires a service_name to work properly." );
+      throw new Error("Usage error: calculateRequestURL requires `service_name` to work properly." );
+    }
+    if ( params.service_stack === AlLocation.InsightAPI && ! params.noEndpointsResolution ) {
+      // Utilize the endpoints service to determine which location to use for this service/account pair
+      const serviceCollection = await this.prepare( params );
+      fullPath = serviceCollection[params.service_name];
+    } else {
+      // Otherwise, just use the built-in defaults
+      fullPath = AlLocatorService.resolveURL( params.service_stack );
     }
     fullPath += `/${params.service_name}`;
     if ( params.version ) {
@@ -350,37 +368,66 @@ export class AlApiClient
     if (params.hasOwnProperty('path') && params.path.length > 0 ) {
       fullPath += ( params.path[0] === '/' ? '' : '/' )  + params.path;
     }
-    return this.getEndpoint(params)
-      .then(serviceURI => ({ host: serviceURI.data[params.service_name], path: fullPath }))
-      .catch(() => ({ host: defaultEndpoint.global, path: fullPath }));
+    return fullPath;
   }
 
-  public async normalizeRequest(config: APIRequestParams):Promise<APIRequestParams> {
-    if ( config.hasOwnProperty("service_name" ) ) {
-      // If we are using endpoints resolution to determine our calculated URL, merge defaultServiceParams into our configuration
-      config = Object.assign( {}, this.defaultServiceParams, config );       //  clever
-      let target = await this.calculateEndpointURI( config );
-      config.url = `https://${target.host}${target.path}`;
-    }
-    if (config.accept_header) {
-      if ( ! config.headers ) {
-        config.headers = {};
+  /**
+   * This method (and its partner, getServiceEndpoints) uses running promise sequences to retrieve endpoints (using the multiple endpoint lookup action)
+   * in such a way that
+   *    a) most basic services will be retrieved in a single call
+   *    b) the initial call is guaranteed to included the service a request is being formed for
+   *    c) only one outstanding call to the endpoints service will be issued, per account, at a given time
+   */
+  protected async prepare( requestParams:APIRequestParams ):Promise<AlEndpointsServiceCollection> {
+    const accountId = requestParams.account_id || this.defaultAccountId || "0";
+    if ( ! this.endpointResolution.hasOwnProperty( accountId ) ) {
+      let serviceList = AlApiClient.defaultServiceList;
+      if ( ! serviceList.includes( requestParams.service_name ) ) {
+        serviceList.push( requestParams.service_name );
       }
-      config.headers.Accept = config.accept_header;
-      delete config.accept_header;
+      this.endpointResolution[accountId] = this.getServiceEndpoints( accountId, serviceList );
     }
-    if (config.response_type) {
-      config.responseType = config.response_type;
-      delete config.response_type;
+    let collection = await this.endpointResolution[accountId];
+    if ( collection.hasOwnProperty( requestParams.service_name ) ) {
+      return collection;
     }
+    this.deleteCachedValue( `/endpoints/${accountId}` );    //  If we reach this point, we don't already have endpoints data for the service being requested -- so, jettison any cached data and ask again.
+    this.endpointResolution[accountId] = this.getServiceEndpoints( accountId, Object.keys( collection ).concat( requestParams.service_name ) );
+    return this.endpointResolution[accountId];
+  }
 
-    return config;
+  protected async getServiceEndpoints( accountId:string, serviceList:string[] ):Promise<AlEndpointsServiceCollection> {
+    const cacheKey = `/endpoints/${accountId}`;
+    let cached = this.getCachedValue<AlEndpointsServiceCollection>( cacheKey );
+    if ( cached ) {
+        return cached;
+    }
+    const endpointsRequest = {
+      method: "POST",
+      url: AlLocatorService.resolveURL( AlLocation.GlobalAPI, `/endpoints/v1/${accountId}/residency/default/endpoints` ),
+      data: serviceList
+    };
+    return this.axiosRequest( endpointsRequest )
+              .then( response => {
+                  let translated = {};
+                  Object.entries( response.data ).forEach( ( [ serviceName, endpointHost ] ) => {
+                    translated[serviceName] = ( endpointHost as string ).startsWith( "http") ? endpointHost : `https://${endpointHost}`;        // ensure that all domains are prefixed with protocol
+                  } );
+                  this.setCachedValue( cacheKey, translated, 15 * 60 * 1000 );
+                  return translated as AlEndpointsServiceCollection;
+              }, error => {
+                console.warn("Could not get endpoints response!  Using defaults." );
+                let serviceLocations:{[serviceId:string]:string} = {};
+                serviceList.forEach( serviceId => { serviceLocations[serviceId] = AlLocatorService.resolveURL( AlLocation.InsightAPI ); } );
+                this.setCachedValue( cacheKey, serviceList, 5 * 60 * 1000 );
+                return Promise.resolve( serviceLocations );
+              } );
   }
 
   /**
    * Instantiate a properly configured axios client for services
    */
-  getAxiosInstance(): AxiosInstance {
+  protected getAxiosInstance(): AxiosInstance {
     if ( this.instance ) {
       return this.instance;
     }
@@ -390,21 +437,44 @@ export class AlApiClient
     };
 
     this.instance = axios.create({
-      baseURL: this.getDefaultEndpoint().global,
-      timeout: 5000,
-      withCredentials: false,
+      timeout: 10000,
+      withCredentials: true,
       headers: headers
     });
 
     this.instance.interceptors.request.use(
       config => {
         this.events.trigger( new AlClientBeforeRequestEvent( config ) );        //    Allow event subscribers to modify the request (e.g., add a session token header) if they want
+        config.validateStatus = ( responseStatus:number ) => {
+            //  This forces all responses to run through our response interceptor
+            return true;
+        };
         return config;
       }
     );
-    this.instance.interceptors.response.use(  response => response,
-                                              error => Promise.reject( error.response ));
+    this.instance.interceptors.response.use( response => this.onRequestResponse( response ) );
     return this.instance;
+  }
+
+  protected onRequestResponse = ( response:AxiosResponse ):Promise<AxiosResponse> => {
+    if ( response.status < 200 || response.status >= 400 ) {
+      return this.onRequestError( response );
+    }
+    return Promise.resolve( response );
+  }
+
+  protected onRequestError = ( errorResponse:AxiosResponse ):Promise<any> => {
+    if ( errorResponse.status >= 500 ) {
+        //  TODO: dispatch service error event
+        console.error(`APIClient Warning: received response ${errorResponse.status} from API request`, errorResponse );
+    } else if ( errorResponse.status >= 400 ) {
+        //  TODO: dispatch client request error event
+        console.error(`APIClient Warning: received response ${errorResponse.status} from API request`, errorResponse );
+    } else if ( errorResponse.status < 200 ) {
+        //  TODO: not quite sure...
+        console.error(`APIClient Warning: received ${errorResponse.status} from API request`, errorResponse );
+    }
+    return Promise.reject( errorResponse );
   }
 
   /**
@@ -412,7 +482,7 @@ export class AlApiClient
    * will catch errors of status code 0/3XX/5XX and retry them at staggered intervals (by default, a factorial delay based on number of retries).
    * If any of these requests succeed, the outer promise will be satisfied using the successful result.
    */
-  async axiosRequest( config:APIRequestParams, attemptIndex:number = 0 ):Promise<AxiosResponse> {
+  protected async axiosRequest<ResponseType = any>( config:APIRequestParams, attemptIndex:number = 0 ):Promise<AxiosResponse<ResponseType>> {
     const ax = this.getAxiosInstance();
     return ax( config ).then( response => {
                                 if ( attemptIndex > 0 ) {
@@ -440,7 +510,7 @@ export class AlApiClient
   /**
    * Utility method to determine whether a given response is a retryable error.
    */
-  isRetryableError( error:AxiosResponse, config:APIRequestParams, attemptIndex:number ) {
+  protected isRetryableError( error:AxiosResponse, config:APIRequestParams, attemptIndex:number ) {
     if ( ! config.hasOwnProperty("retry_count" ) || attemptIndex >= config.retry_count ) {
       return false;
     }
@@ -460,7 +530,7 @@ export class AlApiClient
   /**
    * Generates a random cache-busting parameter
    */
-  generateCacheBuster( attemptIndex:number ) {
+  protected generateCacheBuster( attemptIndex:number ) {
     const verbs = ['debork', 'breaker', 'breaker-breaker', 'fix', 'unbork', 'corex', 'help'];
     const verb = verbs[Math.floor( Math.random() * verbs.length )];
     const hash = ( Date.now() % 60000 ).toString() + Math.floor( Math.random() * 100000 ).toString();
@@ -470,16 +540,19 @@ export class AlApiClient
   /**
    *
    */
-  private getCachedValue( key:string):any {
-    return this.cache.get( key );
+  private getCachedValue<ResponseType = any>( key:string):ResponseType {
+    return this.storage.get( key ) as ResponseType;
   }
 
   private setCachedValue( key:string, data:any, ttl:number ):void {
-    this.cache.put( key, data, ttl );
+    if ( ttl < 1000 ) {
+      return;
+    }
+    this.storage.set( key, data, Math.floor( ttl / 1000 ) );
   }
 
   private deleteCachedValue( key:string ):void {
-    this.cache.del( key );
+    this.storage.delete( key );
   }
 
   /**
@@ -500,4 +573,4 @@ export class AlApiClient
 }
 
 /* tslint:disable:variable-name */
-export const AlDefaultClient = new AlApiClient();
+export const AlDefaultClient = AlGlobalizer.instantiate( 'ALClient', () => new AlApiClient() );

--- a/src/al-api-client.ts
+++ b/src/al-api-client.ts
@@ -108,6 +108,7 @@ export class AlApiClient
    * Alias for GET utility method
    */
   public async fetch(config: APIRequestParams) {
+    console.warn("Deprecation warning: do not use AlApiClient.fetch; use `get` instead." );
     return this.get( config );
   }
 
@@ -153,6 +154,7 @@ export class AlApiClient
    * Alias for PUT utility method
    */
   public async set( config:APIRequestParams ) {
+    console.warn("Deprecation warning: do not use AlApiClient.set; use `put` instead." );
     return this.put( config );
   }
 

--- a/test/al-api-client.spec.ts
+++ b/test/al-api-client.spec.ts
@@ -1,5 +1,5 @@
 import { ALClient, APIRequestParams } from '../src/index';
-import { AlLocatorService, AlLocationContext } from '@al/common';
+import { AlLocatorService, AlLocationContext, AlLocation } from '@al/common';
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
 import xhrMock, { once } from 'xhr-mock';
@@ -47,28 +47,24 @@ const defaultAuthResponse = {
 beforeEach(() => {
     xhrMock.setup()
     AlLocatorService.setContext( { environment: "integration" } );      //  for unit tests, assume integration environment
+    ALClient['endpointResolution']["0"] = Promise.resolve( {
+      "cargo": "https://api.global-integration.product.dev.alertlogic.com",
+      "kevin": "https://kevin.product.dev.alertlogic.com",
+      'search': "https://api.global-fake-integration.product.dev.alertlogic.com",
+      "aims": "https://api.global-integration.product.dev.alertlogic.com"
+    } );
+    ALClient['endpointResolution']["2"] = ALClient['endpointResolution'][0];
+    ALClient['endpointResolution']["67108880"] = ALClient['endpointResolution'][0];
 } );
-afterEach(() => xhrMock.teardown());
-
-describe('when determining an endpoint for a given service', () => {
-  it('should return the resolved endpoint from the service', async () => {
-    const serviceName = 'cargo';
-    const responseBody = {
-      cargo: 'api.global-integration.product.dev.alertlogic.com'
-    };
-    xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/cargo/endpoint/api', {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
-    const endpoint = await ALClient.getEndpoint({ service_name: serviceName });
-    expect(endpoint.data).to.deep.equals(responseBody);
-  });
+afterEach(() => {
+  xhrMock.teardown();
+  ALClient.reset();
 });
 
-describe('when calculating an endpoint URI', () => {
+describe('when calculating request URLs', () => {
   describe('with no params supplied', () => {
     it('should throw an error', async () => {
-      let result = await ALClient.calculateEndpointURI( {} )
+      let result = await ALClient['calculateRequestURL']( {} )
           .then( r => {
             expect( false ).to.equal( true );       //  this should never occur
           } ).catch( e => {
@@ -78,150 +74,110 @@ describe('when calculating an endpoint URI', () => {
   });
   describe('with parameters', () => {
     it('should return targets with correct hosts and paths', async () => {
-      const serviceEndpointHost = 'api.global-integration.product.dev.alertlogic.com';
-      const responseBody = {
-        'kevin': 'kevin.product.dev.alertlogic.com',
-        'cargo': serviceEndpointHost,
-        'search': 'api.global-fake-integration.product.dev.alertlogic.com',
-        'aims': serviceEndpointHost
-      };
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/2/residency/default/services/cargo/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify(responseBody)
-      });
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/12345678/residency/default/services/kevin/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify(responseBody)
-      });
+      let endpointURL = await ALClient['calculateRequestURL']({ service_name: 'cargo', service_stack: AlLocation.InsightAPI });
+      // path should default to /:service_name/v1, no trailing slash
+      expect(endpointURL).to.equal( "https://api.global-integration.product.dev.alertlogic.com/cargo" );
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/aims/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify(responseBody)
-      });
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'aims', version: 'v4', service_stack: AlLocation.InsightAPI  } );
+      //  path should be /:service_name/:version, no trailing slash
+      expect(endpointURL).to.equal( "https://api.global-integration.product.dev.alertlogic.com/aims/v4" );
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/67108880/residency/default/services/aims/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify( responseBody )
-      } );
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'cargo', version: 'v2', account_id: '67108880', service_stack: AlLocation.InsightAPI  } );
+      //  path should be /:service_name/:version/:accountId, no trailing slash
+      expect( endpointURL ).to.equal( `https://api.global-integration.product.dev.alertlogic.com/cargo/v2/67108880` );
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/67108880/residency/default/services/cargo/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify( responseBody )
-      } );
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'search', version: 'v1', path: 'global-capabilities', service_stack: AlLocation.InsightAPI  } );
+      //  domain should be non-default; path should be /:service_name/:version/:path
+      expect( endpointURL ).to.equal( `https://api.global-fake-integration.product.dev.alertlogic.com/search/v1/global-capabilities` );
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/search/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify( responseBody )
-      } );
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'aims', version: 'v100', account_id: '67108880', path: '/some/arbitrary/path/', service_stack: AlLocation.InsightAPI  } );
+      //  path should be /:service_name/:version/:accountId, trailing slash ONLY because it is included in path, but no double slash from the slash at the beginning of `path`
+      expect( endpointURL ).to.equal( "https://api.global-integration.product.dev.alertlogic.com/aims/v100/67108880/some/arbitrary/path/" );
 
-      xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/2/residency/default/services/search/endpoint/api`, {
-        status: 200,
-        body: JSON.stringify( responseBody )
-      } );
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'search', version: 2, account_id: '2', path: '/some/endpoint', params: { a: 1, b: 2, c: 3 }, service_stack: AlLocation.InsightAPI  } );
+      //  query params should not be applied by this stage -- axios serializes them and dispatches them during the actual request execution
+      expect( endpointURL ).to.equal( "https://api.global-fake-integration.product.dev.alertlogic.com/search/v2/2/some/endpoint" );
 
-      let endpoint = await ALClient.calculateEndpointURI({ service_name: 'cargo' });
-      expect(endpoint.host).to.equal( serviceEndpointHost );
-      expect(endpoint.path).to.equal( `/cargo` );                //  path should default to /:service_name/v1, no trailing slash
-
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'aims', version: 'v4' } );
-      expect(endpoint.host).to.equal( serviceEndpointHost );
-      expect(endpoint.path).to.equal( `/aims/v4` );                 //  path should be /:service_name/:version, no trailing slash
-
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'cargo', version: 'v2', account_id: '67108880' } );
-      expect( endpoint.host ).to.equal( serviceEndpointHost );
-      expect( endpoint.path ).to.equal( `/cargo/v2/67108880` );      //  path should be /:service_name/:version/:accountId, no trailing slash
-
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'search', version: 'v1', path: 'global-capabilities' } );
-      expect( endpoint.host ).to.equal( `api.global-fake-integration.product.dev.alertlogic.com` );     //  domain should be non-default
-      expect( endpoint.path ).to.equal( `/search/v1/global-capabilities` );                                     //  path should be /:service_name/:version/:path
-
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'aims', version: 'v100', account_id: '67108880', path: '/some/arbitrary/path/' } );
-      expect( endpoint.host ).to.equal( serviceEndpointHost );
-      expect( endpoint.path ).to.equal( `/aims/v100/67108880/some/arbitrary/path/` );       //  path should be /:service_name/:version/:accountId, trailing slash ONLY because it is included in path, but no double slash from the slash at the beginning of `path`
-
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'search', version: 2, account_id: '2', path: '/some/endpoint', params: { a: 1, b: 2, c: 3 } } );
-      expect( endpoint.host ).to.equal( `api.global-fake-integration.product.dev.alertlogic.com` );
-      expect( endpoint.path ).to.equal( `/search/v2/2/some/endpoint` );                     //  query params should not be applied by this stage -- axios serializes them and dispatches them during the actual request execution
-
-      ALClient.defaultAccountId = "12345678";
-      endpoint = await ALClient.calculateEndpointURI( { service_name: 'kevin', version: 16, path: 'some/arbitrary/endpoint' } );
-      expect( endpoint.host ).to.equal( `kevin.product.dev.alertlogic.com` );
-      expect( endpoint.path ).to.equal( `/kevin/v16/some/arbitrary/endpoint` );
+      ALClient.defaultAccountId = "67108880";
+      endpointURL = await ALClient['calculateRequestURL']( { service_name: 'kevin', version: 16, path: 'some/arbitrary/endpoint', service_stack: AlLocation.InsightAPI } );
+      expect( endpointURL ).to.equal( `https://kevin.product.dev.alertlogic.com/kevin/v16/some/arbitrary/endpoint` );
       ALClient.defaultAccountId = null;
-
     });
   });
-  describe('and an exception is thrown from the backend service', () => {
-    it('should return an endpoint response containing the default global endpoint', async () => {
-      xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/aims/endpoint/api', {
+  describe("and an exception is thrown from the `endpoints` service", () => {
+    it("should fall back to default values", async () => {
+      xhrMock.post( 'https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/10101010/residency/default/endpoints', once({
         status: 500,
-        body: '',
-      });
-      const endpoint = await ALClient.calculateEndpointURI({ service_name: 'aims', version: 1 });
-      expect(endpoint.host).to.equal( 'api.global-integration.product.dev.alertlogic.com' );
-      expect( endpoint.path ).to.equal( '/aims/v1' );
-    });
-  });
+        body: 'Internal Error Or Something'
+      }) );
+
+      let url = await ALClient['calculateRequestURL']( { service_name: 'aims', version: 1, path: '/something', account_id: "10101010", service_stack: AlLocation.InsightAPI } );
+      expect( url ).to.equal( 'https://api.product.dev.alertlogic.com/aims/v1/10101010/something' );
+    } );
+  } );
 });
 
 describe('When performing two fetch operations', () => {
-  beforeEach(() => {
-    // mock out endpoints call first
-    const serviceEndpointHost = 'api.global-integration.product.dev.alertlogic.com';
-    const responseBody = {
-      aims: serviceEndpointHost
-    };
-    xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/2/residency/default/services/aims/endpoint/api`, {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
-  });
-
-  describe(' with the TTL overridden zero ms', () => {
+  describe(' with no TTL', () => {
     it('should return fresh data without caching', async () => {
       // Here we mock out a second response from back end...
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users', once({
         status: 200,
         body: 'first response',
       }));
-      await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' });                            //  fetch once
+      await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' });                            //  fetch once
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users', once({
         status: 200,
         body: 'second response',
       }));
-      let response = await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', ttl: 0 });     //  fetch again, TTL 0 to disable caching
+      let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users'});     //  fetch again, TTL 0 to disable caching
       expect(response).to.equal('second response');
     });
   });
-  describe('with no TTL override value supplied', () => {
+  describe('with caching enabled', () => {
     it('should return the first server response', async () => {
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users', once({
         status: 200,
         body: 'first response',
       }));
-      await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', ttl: 60000 });
+      await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', ttl: true });
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users', once({
         status: 200,
         body: 'second response',
       }));
-      let response = await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' });
+      let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', ttl: true });
       expect(response).to.equal('first response');
     });
   });
-  describe('with query params supplied', () => {
+  describe('with caching enabled and the same query params supplied', () => {
     it('should return the first server response', async () => {
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar', once({
         status: 200,
         body: 'first response',
       }));
-      await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', params: {foo: 'bar'} });
+      await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', params: {foo: 'bar'}, ttl: true });
       xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar', once({
         status: 200,
         body: 'second response',
       }));
-      let response = await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: 'bar'}});
+      let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: 'bar'}, ttl: true });
       expect(response).to.equal('first response');
+    });
+  });
+  describe('with caching enabled and different query params supplied', () => {
+    it('should return the second server response', async () => {
+      xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar', once({
+        status: 200,
+        body: 'first response',
+      }));
+      await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', params: {foo: 'bar'}, ttl: true });
+      xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=baz', once({
+        status: 200,
+        body: 'second response',
+      }));
+      let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: 'baz'}, ttl: true });
+      expect(response).to.equal('second response');
     });
   });
 });
@@ -230,17 +186,6 @@ describe('When authenticating a user with credentials', () => {
   const username = 'bob@email.com';
   const password = 'IAmNotAValidUser!@#$';
   const mfaCode = '123456';
-  beforeEach(() => {
-    // mock out endpoints call first
-    const serviceName = 'aims';
-    const serviceEndpoint = 'api.global-integration.product.dev.alertlogic.com';
-    const responseBody = {};
-    responseBody[serviceName] = serviceEndpoint;
-    xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/${serviceName}/endpoint/api`, {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
-  });
   describe('but without supplying an mfa code', () => {
     it('should perform the authenticate request and set underlying session details using the response returned', async() => {
       xhrMock.post('https://api.global-integration.product.dev.alertlogic.com/aims/v1/authenticate', (req, res) => {
@@ -248,7 +193,8 @@ describe('When authenticating a user with credentials', () => {
         expect(req.body()).to.equal('{}');
         return res.status(200).body(defaultAuthResponse);
       });
-      await ALClient.authenticate(username, password);
+      const sessionDescriptor = await ALClient.authenticate(username, password, undefined, true );
+      expect( sessionDescriptor ).to.deep.equals( defaultAuthResponse );
     });
   });
   describe('and an mfa code supplied', () => {
@@ -258,7 +204,12 @@ describe('When authenticating a user with credentials', () => {
         expect(JSON.parse(req.body())).to.deep.equals({mfa_code: mfaCode});
         return res.status(200).body(defaultAuthResponse);
       });
-      await ALClient.authenticate(username, password, mfaCode);
+      try {
+        const sessionDescriptor = await ALClient.authenticate(username, password, mfaCode, true );
+        expect( sessionDescriptor ).to.deep.equals( defaultAuthResponse );
+      } catch( e ) {
+        console.error("Got error...", e );
+      }
     });
   });
 });
@@ -266,24 +217,13 @@ describe('When authenticating a user with credentials', () => {
 describe('When authenticating a user with a session token and mfa code', () => {
   const sessionToken = 'Ses1ion.Tok3n==';
   const mfaCode = '123456';
-  beforeEach(() => {
-    // mock out endpoints call first
-    const serviceName = 'aims';
-    const serviceEndpoint = 'api.global-integration.product.dev.alertlogic.com';
-    const responseBody = {};
-    responseBody[serviceName] = serviceEndpoint;
-    xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/${serviceName}/endpoint/api`, {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
-  });
   it('should perform the authenticate request using the session token as a header and mfa code as a body param', async() => {
     xhrMock.post('https://api.global-integration.product.dev.alertlogic.com/aims/v1/authenticate', (req, res) => {
       expect(req.header('X-AIMS-Session-Token')).to.equal(sessionToken);
       expect(JSON.parse(req.body())).to.deep.equals({ mfa_code: mfaCode });
       return res.status(200).body(defaultAuthResponse);
     });
-    await ALClient.authenticateWithMFASessionToken(sessionToken, mfaCode);
+    await ALClient.authenticateWithMFASessionToken(sessionToken, mfaCode, true );
   });
 });
 
@@ -291,7 +231,7 @@ describe('retry logic', () => {
   it( 'should generate random cache breakers for every retry call', () => {
     let previousValues = [];
     for ( let i = 0; i < 100; i++ ) {
-        let breaker = ALClient.generateCacheBuster( Math.floor( Math.random() * 5 ) );      //    cache busters should be suitably random to avoid overlaps
+        let breaker = ALClient['generateCacheBuster']( Math.floor( Math.random() * 5 ) );      //    cache busters should be suitably random to avoid overlaps
         expect( previousValues.indexOf( breaker ) ).to.equal( -1 );
         previousValues.push( breaker );
     }
@@ -301,56 +241,37 @@ describe('retry logic', () => {
         retry_count: 10,
         url: "https://some.com/made/up/url"
     };
-    expect( ALClient.isRetryableError( { data: {}, status: 500, statusText: "Something", config: {}, headers: {} }, config, 0 ) ).to.equal( true );
-    expect( ALClient.isRetryableError( { data: {}, status: 503, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
-    expect( ALClient.isRetryableError( { data: {}, status: 302, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
-    expect( ALClient.isRetryableError( { data: {}, status: 0, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
-    expect( ALClient.isRetryableError( { data: {}, status: 0, statusText: "Something", config: {}, headers: {} }, config, 10  ) ).to.equal( false );
-    expect( ALClient.isRetryableError( { data: {}, status: 204, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
-    expect( ALClient.isRetryableError( { data: {}, status: 404, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
-    expect( ALClient.isRetryableError( { data: {}, status: 403, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
+    expect( ALClient['isRetryableError']( { data: {}, status: 500, statusText: "Something", config: {}, headers: {} }, config, 0 ) ).to.equal( true );
+    expect( ALClient['isRetryableError']( { data: {}, status: 503, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
+    expect( ALClient['isRetryableError']( { data: {}, status: 302, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
+    expect( ALClient['isRetryableError']( { data: {}, status: 0, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( true );
+    expect( ALClient['isRetryableError']( { data: {}, status: 0, statusText: "Something", config: {}, headers: {} }, config, 10  ) ).to.equal( false );
+    expect( ALClient['isRetryableError']( { data: {}, status: 204, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
+    expect( ALClient['isRetryableError']( { data: {}, status: 404, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
+    expect( ALClient['isRetryableError']( { data: {}, status: 403, statusText: "Something", config: {}, headers: {} }, config, 0  ) ).to.equal( false );
   } );
   it('should retry if retry_count is specified', async () => {
     xhrMock.reset();
-    const serviceEndpointHost = 'api.global-integration.product.dev.alertlogic.com';
-    const responseBody = {
-      'aims': serviceEndpointHost
-    };
-    xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/10101010/residency/default/services/aims/endpoint/api', {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
     // Here we mock out a second response from back end...
-    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/10101010\\/users.*", "i" ), once({
+    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/2\\/users.*", "i" ), once({
       status: 500,
       body: 'Unexpected result',
     }));
-    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/10101010\\/users.*", "i" ), once({
+    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/2\\/users.*", "i" ), once({
       status: 500,
       body: 'Unexpected result',
     }));
-    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/10101010\\/users.*", "i" ), once({
+    xhrMock.get( new RegExp( "https://api.global\\-integration\\.product\\.dev\\.alertlogic\\.com\\/aims\\/v1\\/2\\/users.*", "i" ), once({
       status: 200,
       body: 'Final result',
     }));
-    const result = await ALClient.fetch({ service_name: 'aims', version: 'v1', account_id: '10101010', path: 'users', retry_count: 3, retry_interval: 10 });                            //  fetch once
+    const result = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', retry_count: 3, retry_interval: 10 });                            //  fetch once
     expect( result ).to.equal( "Final result" );
   });
 } );
 
 // HTTP Operations
 describe('When', () => {
-  beforeEach(() => {
-    // mock out endpoints call first
-    const serviceName = 'aims';
-    const serviceEndpoint = 'api.global-integration.product.dev.alertlogic.com';
-    const responseBody = {};
-    responseBody[serviceName] = serviceEndpoint;
-    xhrMock.get(`https://api.global-integration.product.dev.alertlogic.com/endpoints/v1/0/residency/default/services/${serviceName}/endpoint/api`, {
-      status: 200,
-      body: JSON.stringify(responseBody),
-    });
-  });
   describe('posting form data', () => {
     it('should perform a POST operation with Content-Type header set to a value of "multipart/form-data"', async() => {
       const apiRequestParams: APIRequestParams = {service_name: 'aims', version: 'v1', account_id: '2'};
@@ -383,7 +304,7 @@ describe('When', () => {
         expect(req.method()).to.equal('PUT');
         return res.status(200).body({});
       });
-      await ALClient.set(apiRequestParams).then((r) => {
+      await ALClient.put(apiRequestParams).then((r) => {
         expect(apiRequestParams.method).to.equal('PUT');
       });
     });
@@ -402,24 +323,6 @@ describe('When', () => {
   });
 });
 describe('when normalizing an outgoing request config',() => {
-  describe('containing a service_name property', () => {
-    let stub;
-    beforeEach(() => {
-      stub = sinon.stub(ALClient, 'calculateEndpointURI').resolves({
-        host: 'xxx',
-        path: '/hfdjdshfh'
-      });
-    });
-    afterEach(() => {
-      stub.restore();
-    });
-    it('should set the config url to the fully resolved value for the service_name value', async() => {
-      const config: APIRequestParams = { service_name: 'foo'};
-      await ALClient.normalizeRequest(config).then((c) => {
-        expect(c.url).to.deep.equals('https://xxx/hfdjdshfh');
-      });
-    });
-  });
   describe('with an accept_header property', () => {
     it('set a headers object on the config object with an Accept prop set to the value of the original accept_header value', async() => {
       const config: APIRequestParams = { accept_header: 'foo/bar'};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,9 @@
     "declarationDir": "./dist/typings/",
     "lib": [
       "es6",
-      "es2015",
+      "es2017",
       "dom"
-    ],
-
+    ]
   },
   "files": [
     "./src/index.ts"

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
         "no-else-after-return": false,
         "no-parameter-reassignment": false,
         "space-in-parens": false,
+        "space-before-function-paren": false,
         "quotemark": false,
         "object-curly-spacing": false,
         "object-literal-shorthand": false,


### PR DESCRIPTION
- Updated AlApiClient to use the multiple endpoint lookup endpoint,
  instead of looking up each endpoint individually
- Prevent multiple endpoint lookups for a given account/residency pair
  from executing simultaneously
- Added provisional support for interacting with other API stacks via
  service
- Added option to reset state/override global request options
- Added placeholder for generalized error collation and reporting
- Added deprecation notices to not-standard `fetch` and `set` methods on AlApiClient.