### PR TITLE
Miscellaneous Enhancements (v1.1.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/client",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "MIT",
   "description": "A client to abstract common Public API functionality",
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './types';
 export * from './events';
 export * from './json-schematics';
 export {
+    AlEndpointsServiceCollection,
     AlApiClient,
     AlDefaultClient,
     AlDefaultClient as ALClient,    /* @deprecated */


### PR DESCRIPTION
- Bumped version to 1.1.6
- Added support for custom cache keys.  This allows requests to the same
  path with different headers to still use the built-in caching system.
- Added `catch` for unhandled request errors, including generic Network
  Errors.  This should subject such failures to retry logic with a cache-busting parameter.
- Exposed `getServiceEndpoints` as a public method, along with its return type `AlEndpointsServiceCollection`
