### PR TITLE
1.2.2 - Handle query param array values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "description": "A client to abstract common Public API functionality",
   "author": {

--- a/test/al-api-client.spec.ts
+++ b/test/al-api-client.spec.ts
@@ -174,6 +174,21 @@ describe('When performing two fetch operations', () => {
       let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: 'bar'}, ttl: true });
       expect(response).to.equal('first response');
     });
+    describe('which contain an array of values', () => {
+      it('should return the first server response', async () => {
+        xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar&foo=meow', once({
+          status: 200,
+          body: 'first response',
+        }));
+        await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users', params: {foo: ['bar', 'meow']}, ttl: true });
+        xhrMock.get('https://api.global-integration.product.dev.alertlogic.com/aims/v1/2/users?foo=bar&foo=meow', once({
+          status: 200,
+          body: 'second response',
+        }));
+        let response = await ALClient.get({ service_name: 'aims', version: 'v1', account_id: '2', path: 'users' , params: {foo: ['bar', 'meow']}, ttl: true });
+        expect(response).to.equal('first response');
+      });
+    });
   });
   describe('with caching enabled and different query params supplied', () => {
     it('should return the second server response', async () => {


### PR DESCRIPTION
### 1.2.1
Enhancement to deal with supplied query parameters containing arrays of values.

**Current behaviour:**
````
params = {
    foo: ['bar','meow']
}
````
Gets serialized to `foo[]=bar&foo[]=meow`

**New Behaviour:**

This change, will now correctly serialize as `foo=bar&foo=meow`

